### PR TITLE
Reproduce path error on windows gorilla#588

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -16,6 +16,13 @@ on:
     - staging
     - develop
 
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+    # The concurrency group contains the workflow name and the branch name for pull requests
+    # or the commit hash for any other events.
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    cancel-in-progress: true
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # The "build" workflow

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,7 +21,7 @@ jobs:
   # The "build" workflow
   build:
     # The type of runner that the job will run on
-    runs-on: [windows-latest, ubuntu-latest]
+    runs-on: [windows-latest]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,7 +21,7 @@ jobs:
   # The "build" workflow
   build:
     # The type of runner that the job will run on
-    runs-on: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: windows-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,56 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Continous Integration
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches:
+    - master
+    - staging
+    - develop
+  pull_request:
+    branches:
+    - master
+    - staging
+    - develop
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # The "build" workflow
+  build:
+    # The type of runner that the job will run on
+    runs-on: [macos-latest, ubuntu-latest, windows-latest]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+    
+    # Setup Go
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.18.0' # The Go version to download (if necessary) and use.
+    
+    # Install all the dependencies
+    - name: Install dependencies
+      run: |
+        go version
+        go get -u golang.org/x/lint/golint
+        
+    # Run build of the application
+    - name: Run build
+      run: go build . 
+      
+    # Run vet & lint on the code
+    - name: Run vet & lint
+      run: |
+        go vet .
+        golint .
+    
+    # Run testing on the code
+    - name: Run test suites
+      run: go test -v
+    

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,7 +21,7 @@ jobs:
   # The "build" workflow
   build:
     # The type of runner that the job will run on
-    runs-on: [windows-latest]
+    runs-on: [windows-latest, ubuntu-latest]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -7,9 +7,11 @@ name: Continous Integration
 on:
   push:
     branches:
-    - '*'
-  pull_request:
-    - '*' 
+      - '*'
+    pull_request:
+      - '*'
+    tags:
+      - '*'
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,7 +21,7 @@ jobs:
   # The "build" workflow
   build:
     # The type of runner that the job will run on
-    runs-on: [windows-latest, ubuntu-20.04]
+    runs-on: ['windows-latest', 'ubuntu-20.04']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,7 +21,7 @@ jobs:
   # The "build" workflow
   build:
     # The type of runner that the job will run on
-    runs-on: windows-latest
+    runs-on: [windows-latest, ubuntu-latest, macos-latest]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -48,7 +48,6 @@ jobs:
     - name: Run vet & lint
       run: |
         go vet .
-        golint .
     
     # Run testing on the code
     - name: Run test suites

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,7 +21,7 @@ jobs:
   # The "build" workflow
   build:
     # The type of runner that the job will run on
-    runs-on: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: [windows-latest, ubuntu-latest]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,7 +21,10 @@ jobs:
   # The "build" workflow
   build:
     # The type of runner that the job will run on
-    runs-on: ['windows-latest', 'ubuntu-20.04']
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,7 +21,7 @@ jobs:
   # The "build" workflow
   build:
     # The type of runner that the job will run on
-    runs-on: [windows-latest, ubuntu-latest]
+    runs-on: [windows-latest, ubuntu-20.04]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        golang: ["latest", "1.17", "1.16"]
+        golang: ["1.18", "1.17", "1.16"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -7,14 +7,9 @@ name: Continous Integration
 on:
   push:
     branches:
-    - master
-    - staging
-    - develop
+    - '*'
   pull_request:
-    branches:
-    - master
-    - staging
-    - develop
+    - '*' 
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
@@ -42,7 +37,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.18.0' # The Go version to download (if necessary) and use.
+        go-version: '>=1.13' # The Go version to download (if necessary) and use.
     
     # Install all the dependencies
     - name: Install dependencies

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,6 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        golang: ["latest", "1.17", "1.16"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -39,7 +40,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '>=1.13' # The Go version to download (if necessary) and use.
+        go-version: ${{matrix.golang}} # The Go version to download (if necessary) and use.
     
     # Install all the dependencies
     - name: Install dependencies

--- a/mux_httpserver_test.go
+++ b/mux_httpserver_test.go
@@ -76,7 +76,7 @@ func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// prepend the path with the path to the static directory
-	path = filepath.Join(h.staticPath, path)
+	// path = filepath.Join(h.staticPath, path)
 
 	// check whether a file exists at the given path
 	_, err = os.Stat(path)

--- a/mux_httpserver_test.go
+++ b/mux_httpserver_test.go
@@ -66,7 +66,8 @@ type spaHandler struct {
 // is suitable behavior for serving an SPA (single page application).
 func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// get the absolute path to prevent directory traversal
-	path, err := filepath.Abs(r.URL.Path)
+	var err error
+	path := filepath.Join(h.staticPath, r.URL.Path)
 	if err != nil {
 		// if we failed to get the absolute path respond with a 400 bad request
 		// and stop

--- a/mux_httpserver_test.go
+++ b/mux_httpserver_test.go
@@ -8,6 +8,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -47,4 +49,82 @@ func TestSchemeMatchers(t *testing.T) {
 		defer s.Close()
 		assertResponseBody(t, s, "hello https world")
 	})
+}
+
+// spaHandler implements the http.Handler interface, so we can use it
+// to respond to HTTP requests. The path to the static directory and
+// path to the index file within that static directory are used to
+// serve the SPA in the given static directory.
+type spaHandler struct {
+	staticPath string
+	indexPath  string
+}
+
+// ServeHTTP inspects the URL path to locate a file within the static dir
+// on the SPA handler. If a file is found, it will be served. If not, the
+// file located at the index path on the SPA handler will be served. This
+// is suitable behavior for serving an SPA (single page application).
+func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// get the absolute path to prevent directory traversal
+	path, err := filepath.Abs(r.URL.Path)
+	if err != nil {
+		// if we failed to get the absolute path respond with a 400 bad request
+		// and stop
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// prepend the path with the path to the static directory
+	path = filepath.Join(h.staticPath, path)
+
+	// check whether a file exists at the given path
+	_, err = os.Stat(path)
+
+	if os.IsNotExist(err) {
+		// file does not exist, serve index.html
+		http.ServeFile(w, r, filepath.Join(h.staticPath, h.indexPath))
+		return
+	} else if err != nil {
+		// if we got an error (that wasn't that the file doesn't exist) stating the
+		// file, return a 500 internal server error and stop
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// otherwise, use http.FileServer to serve the static dir
+	http.FileServer(http.Dir(h.staticPath)).ServeHTTP(w, r)
+}
+
+func TestCustomServeHttp(t *testing.T) {
+	// create a build directory and write a `index.html` file
+	os.Mkdir("build", 0700)
+
+	htmlContent := []byte(`<html><head><title>hello</title></head><body>world</body></html>`)
+
+	err := os.WriteFile("./build/index.html", htmlContent, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+	rr := httptest.NewRecorder()
+	spa := spaHandler{staticPath: "./build", indexPath: "index.html"}
+	spa.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	// Check the response body is what we expect.
+	if rr.Body.String() != string(htmlContent) {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), string(htmlContent))
+	}
+
 }

--- a/mux_httpserver_test.go
+++ b/mux_httpserver_test.go
@@ -170,7 +170,7 @@ func TestServeHttpFilepathAbs(t *testing.T) { // {{{
 	if runtime.GOOS != "windows" && rr.Body.String() != string(htmlContent) {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), string(htmlContent))
-	} else if runtime.GOOS == "windows" && strings.Contains(rr.Body.String(), "syntax is incorrect.") {
+	} else if runtime.GOOS == "windows" && !strings.Contains(rr.Body.String(), "syntax is incorrect.") {
 		t.Errorf("handler returned unexpected body in case of windows: got %v want %v",
 			rr.Body.String(), string(htmlContent))
 	}

--- a/mux_httpserver_test.go
+++ b/mux_httpserver_test.go
@@ -8,8 +8,91 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
+
+// spaHandler implements the http.Handler interface, so we can use it
+// to respond to HTTP requests. The path to the static directory and
+// path to the index file within that static directory are used to
+// serve the SPA in the given static directory.
+type spaHandler struct {
+	staticPath string
+	indexPath  string
+}
+
+// FilepathAbsServeHTTP inspects the URL path to locate a file within the static dir
+// on the SPA handler. If a file is found, it will be served. If not, the
+// file located at the index path on the SPA handler will be served. This
+// is suitable behavior for serving an SPA (single page application).
+// This is a negative test case where `filepath.Abs` will return path value like `D:\`
+// if our route is `/`. As per docs: Abs returns an absolute representation of path. If the path is not absolute it will be joined with the current working directory to turn it into an absolute path. The absolute path name for a given file is not guaranteed to be unique. Abs calls Clean on the result.
+func (h spaHandler) FilepathAbsServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// get the absolute path to prevent directory traversal
+	path, err := filepath.Abs(r.URL.Path)
+	if err != nil {
+		// if we failed to get the absolute path respond with a 400 bad request
+		// and stop
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// prepend the path with the path to the static directory
+	// path = filepath.Join(h.staticPath, path)
+
+	// check whether a file exists at the given path
+	_, err = os.Stat(path)
+
+	if os.IsNotExist(err) {
+		// file does not exist, serve index.html
+		http.ServeFile(w, r, filepath.Join(h.staticPath, h.indexPath))
+		return
+	} else if err != nil {
+		// if we got an error (that wasn't that the file doesn't exist) stating the
+		// file, return a 500 internal server error and stop
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// otherwise, use http.FileServer to serve the static dir
+	http.FileServer(http.Dir(h.staticPath)).ServeHTTP(w, r)
+}
+
+// ServeHTTP inspects the URL path to locate a file within the static dir
+// on the SPA handler. If a file is found, it will be served. If not, the
+// file located at the index path on the SPA handler will be served. This
+// is suitable behavior for serving an SPA (single page application).
+func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// get the absolute path to prevent directory traversal
+	var err error
+	path := filepath.Join(h.staticPath, r.URL.Path)
+	if err != nil {
+		// if we failed to get the absolute path respond with a 400 bad request
+		// and stop
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// check whether a file exists at the given path
+	_, err = os.Stat(path)
+
+	if os.IsNotExist(err) {
+		// file does not exist, serve index.html
+		http.ServeFile(w, r, filepath.Join(h.staticPath, h.indexPath))
+		return
+	} else if err != nil {
+		// if we got an error (that wasn't that the file doesn't exist) stating the
+		// file, return a 500 internal server error and stop
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// otherwise, use http.FileServer to serve the static dir
+	http.FileServer(http.Dir(h.staticPath)).ServeHTTP(w, r)
+}
 
 func TestSchemeMatchers(t *testing.T) {
 	router := NewRouter()
@@ -47,4 +130,79 @@ func TestSchemeMatchers(t *testing.T) {
 		defer s.Close()
 		assertResponseBody(t, s, "hello https world")
 	})
+}
+
+func TestServeHttpFilepathAbs(t *testing.T) {
+	// create a diretory name `build`
+	os.Mkdir("build", 0700)
+
+	// create a file `index.html` and write below content
+	htmlContent := []byte(`<html><head><title>hello</title></head><body>world</body></html>`)
+	err := os.WriteFile("./build/index.html", htmlContent, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make new request
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+	rr := httptest.NewRecorder()
+	spa := spaHandler{staticPath: "./build", indexPath: "index.html"}
+	spa.FilepathAbsServeHTTP(rr, req)
+
+	status := rr.Code
+	if runtime.GOOS != "windows" && status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	} else if runtime.GOOS == "windows" && rr.Code != http.StatusInternalServerError {
+		t.Errorf("handler returned wrong status code in case of windows: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	// Check the response body is what we expect.
+	if runtime.GOOS != "windows" && rr.Body.String() != string(htmlContent) {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), string(htmlContent))
+	} else if runtime.GOOS == "windows" && strings.Contains(rr.Body.String(), "syntax is incorrect.") {
+		t.Errorf("handler returned unexpected body in case of windows: got %v want %v",
+			rr.Body.String(), string(htmlContent))
+	}
+}
+
+func TestServeHttpFilepathJoin(t *testing.T) {
+	// create a diretory name `build`
+	os.Mkdir("build", 0700)
+
+	// create a file `index.html` and write below content
+	htmlContent := []byte(`<html><head><title>hello</title></head><body>world</body></html>`)
+	err := os.WriteFile("./build/index.html", htmlContent, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make new request
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+	rr := httptest.NewRecorder()
+	spa := spaHandler{staticPath: "./build", indexPath: "index.html"}
+	spa.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	// Check the response body is what we expect.
+	if rr.Body.String() != string(htmlContent) {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), string(htmlContent))
+	}
 }

--- a/mux_httpserver_test.go
+++ b/mux_httpserver_test.go
@@ -29,7 +29,10 @@ type spaHandler struct {
 // file located at the index path on the SPA handler will be served. This
 // is suitable behavior for serving an SPA (single page application).
 // This is a negative test case where `filepath.Abs` will return path value like `D:\`
-// if our route is `/`. As per docs: Abs returns an absolute representation of path. If the path is not absolute it will be joined with the current working directory to turn it into an absolute path. The absolute path name for a given file is not guaranteed to be unique. Abs calls Clean on the result.
+// if our route is `/`. As per docs: Abs returns an absolute representation of path.
+// If the path is not absolute it will be joined with the current working directory to turn
+// it into an absolute path. The absolute path name for a given file is not guaranteed to
+// be unique. Abs calls Clean on the result.
 func (h spaHandler) FilepathAbsServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// get the absolute path to prevent directory traversal
 	path, err := filepath.Abs(r.URL.Path)
@@ -41,7 +44,7 @@ func (h spaHandler) FilepathAbsServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	// prepend the path with the path to the static directory
-	// path = filepath.Join(h.staticPath, path)
+	path = filepath.Join(h.staticPath, path)
 
 	// check whether a file exists at the given path
 	_, err = os.Stat(path)
@@ -66,8 +69,8 @@ func (h spaHandler) FilepathAbsServeHTTP(w http.ResponseWriter, r *http.Request)
 // file located at the index path on the SPA handler will be served. This
 // is suitable behavior for serving an SPA (single page application).
 func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// get the absolute path to prevent directory traversal
 	var err error
+	// internally calls path.Clean path to prevent directory traversal
 	path := filepath.Join(h.staticPath, r.URL.Path)
 	if err != nil {
 		// if we failed to get the absolute path respond with a 400 bad request


### PR DESCRIPTION
I just started to look into the issue https://github.com/gorilla/mux/issues/588 

I don't own any windows machine so I created a pipeline for all the major os: `linux`, `macos` and `windows`. This pipeline will execute all the test case including the one which I have added to reproduce the error.

UPDATE: Indeed :100: I can see a test failure here: https://github.com/amustaque97/mux/runs/6677730858?check_suite_focus=true#step:7:95

In other os i.e. `linux` and `macos` test case is passing. 